### PR TITLE
Fixing GHC 7.8 errors

### DIFF
--- a/executables/APITests/Prelude.hs
+++ b/executables/APITests/Prelude.hs
@@ -27,7 +27,7 @@ import Control.Applicative as Exports
 import Control.Arrow as Exports hiding (left, right)
 import Control.Category as Exports
 import Data.Monoid as Exports
-import Data.Foldable as Exports
+import Data.Foldable as Exports hiding (toList)
 import Data.Traversable as Exports hiding (for)
 import Data.Maybe as Exports
 import Data.Either as Exports

--- a/executables/Benchmarks/Prelude.hs
+++ b/executables/Benchmarks/Prelude.hs
@@ -24,7 +24,7 @@ import Control.Applicative as Exports
 import Control.Arrow as Exports hiding (left, right)
 import Control.Category as Exports
 import Data.Monoid as Exports
-import Data.Foldable as Exports
+import Data.Foldable as Exports hiding (toList)
 import Data.Traversable as Exports hiding (for)
 import Data.Maybe as Exports
 import Data.Either as Exports

--- a/graph-db.cabal
+++ b/graph-db.cabal
@@ -74,14 +74,14 @@ library
     th-expand-syns,
     th-instance-reification > 0.1.0 && < 0.2,
     -- networking:
-    remotion == 0.1.*,
+    remotion == 0.2.*,
     network == 2.4.*,
-    network-simple == 0.3.*,
+    network-simple == 0.4.*,
     pipes-network == 0.6.*,
     -- streaming:
     pipes >= 4.0 && < 4.2,
-    pipes-bytestring == 2.0.*,
-    pipes-cereal-plus == 0.3.*,
+    pipes-bytestring == 2.1.*,
+    pipes-cereal-plus == 0.4.*,
     -- file-system:
     directory == 1.2.*,
     filelock == 0.1.*,
@@ -183,14 +183,14 @@ test-suite internal-tests
     th-expand-syns,
     th-instance-reification > 0.1.0 && < 0.2,
     -- networking:
-    remotion == 0.1.*,
+    remotion == 0.2.*,
     network == 2.4.*,
-    network-simple == 0.3.*,
+    network-simple == 0.4.*,
     pipes-network == 0.6.*,
     -- streaming:
     pipes >= 4.0 && < 4.2,
-    pipes-bytestring == 2.0.*,
-    pipes-cereal-plus == 0.3.*,
+    pipes-bytestring == 2.1.*,
+    pipes-cereal-plus == 0.4.*,
     -- file-system:
     directory == 1.2.*,
     filelock == 0.1.*,
@@ -365,7 +365,7 @@ benchmark competition-bench
     safecopy == 0.8.*,
     -- postgres:
     postgresql-simple == 0.4.*,
-    ex-pool == 0.1.*,
+    ex-pool == 0.2.*,
     -- benchmarking:
     criterion-plus == 0.1.*,
     -- concurrency:

--- a/library/GraphDB/Macros/Templates.hs
+++ b/library/GraphDB/Macros/Templates.hs
@@ -43,7 +43,7 @@ renderSetupInstance (setup, indexes, values, indexesFunctionClauses) =
     []
     (AppT (ConT ''G.Setup) (setup))
     [
-      TySynInstD ''G.Algorithm [setup] (ConT ''G.Linear),
+      TySynInstD ''G.Algorithm (TySynEqn [setup] (ConT ''G.Linear)),
       renderSumData ''G.Index setup IsStrict indexes,
       renderSumData ''G.Value setup NotStrict values,
       FunD 'G.indexes (map renderIndexesClause indexesFunctionClauses)

--- a/library/GraphDB/Util/Prelude.hs
+++ b/library/GraphDB/Util/Prelude.hs
@@ -28,10 +28,10 @@ import Control.Applicative as Exports
 import Control.Arrow as Exports hiding (left, right)
 import Control.Category as Exports
 import Data.Monoid as Exports
-import Data.Foldable as Exports
+import Data.Foldable as Exports hiding (toList)
 import Data.Traversable as Exports hiding (for)
 import Data.Maybe as Exports
-import Data.Either as Exports
+import Data.Either as Exports hiding (isLeft, isRight)
 import Data.List as Exports hiding (concat, foldr, foldl1, maximum, minimum, product, sum, all, and, any, concatMap, elem, foldl, foldr1, notElem, or, find, maximumBy, minimumBy, mapAccumL, mapAccumR, foldl')
 import Data.Tuple as Exports
 import Data.Ord as Exports (Down(..))
@@ -41,7 +41,7 @@ import Data.Word as Exports
 import Data.Ratio as Exports
 import Data.Fixed as Exports
 import Data.Ix as Exports
-import Data.Data as Exports
+import Data.Data as Exports hiding (Proxy)
 import Text.Read as Exports (readMaybe, readEither)
 import Control.Exception as Exports hiding (tryJust, assert)
 import Control.Concurrent as Exports hiding (yield)


### PR DESCRIPTION
With the updated th-instance-reification and QuickCheck-GenT (see nikita-volkov/QuickCheck-GenT#2) the tests now also compile and run successfully. I guess it should run on Travis as soon as the QuickCheck-GenT pull request is accepted and pushed to hackage. This seems to have broken the 7.6 job though because of the template-haskell upgrade, which I guess is to be expected.

Now I can have a play with graph-db with the recent Haskell Platform on OSX ! :) 